### PR TITLE
Mention the --prune option for docker stack deploy.

### DIFF
--- a/slides/swarm/stacks.md
+++ b/slides/swarm/stacks.md
@@ -354,6 +354,10 @@ class: extra-details
 
   (But you can use `docker-compose config` to "flatten" your configuration)
 
+- There is still a way the compose file does not reflect the actual deployed stack even when you only do changes in the compose file.
+
+  When removing a service from the file you have to use the option `--prune` to also delete the service from the deployed stack `docker stack deploy --prune`.
+
 ---
 
 ## Summary


### PR DESCRIPTION
You have to use this option in order to actually remove services from a deployed stack without removing and redeploying the stack.

If you don't, you can easily end up with a compose file that is way different from your deployed stack, because all the old and removed services are still deployed.